### PR TITLE
Scale horses correctly

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -21,7 +21,9 @@ def detectRes():
 
     tex = Image.open(searchfold + selected)
     print(tex.size)
-    ro = int(math.sqrt(tex.size[0]/16))
+    ro = 1
+    while math.pow(2, ro) < (tex.size[0]/16):
+        ro += 1
     print('resolution: ' +  str(tex.size[0]) + '  ro: ' + str(ro))
     if (ro<1):ro=1
     return ro
@@ -693,7 +695,7 @@ def main(pack):
 def conversion(res_r):
     global RES_R
     if(res_r == 0):res_r = 1
-    RES_R = int(math.pow(2, res_r)-1)
+    RES_R = int(math.pow(2, res_r))
     changeFileName()
     changeFolderName()
     changeModel()

--- a/src/main.py
+++ b/src/main.py
@@ -21,11 +21,11 @@ def detectRes():
 
     tex = Image.open(searchfold + selected)
     print(tex.size)
-    ro = 1
+    ro = 0
     while math.pow(2, ro) < (tex.size[0]/16):
         ro += 1
     print('resolution: ' +  str(tex.size[0]) + '  ro: ' + str(ro))
-    if (ro<1):ro=1
+    if (ro<0):ro=0
     return ro
 
 def alter(f, old_str, new_str):


### PR DESCRIPTION
scales horse etc images to correct size. Figure out actual power of 2, instead of approximating with square root(??). 128x pack horses convert from 1024 to 512 now as they should instead of converting to 192

Previously, ro = int(math.sqrt(128/16)) gave 2.  RES_R = int(math.pow(2, 2)-1)  gave 3.  Surely that line should have been RES_R = int(math.pow(2, res_r-1)) ?  Horse texture would then be resized to 64*3, or 192x192 instead of 512x512.

Now ro returns as 3, and pow(2, 3) is 8, and 64*8 is 512, as it should be for a 128x resource pack.  The other sizes work too: 16x will give ro as 0, and 2 to the zeroth is 1, so the converted horse textures for a 16x pack will be 64x64, as they should be.